### PR TITLE
fix error in console

### DIFF
--- a/modalmgr.lua
+++ b/modalmgr.lua
@@ -6,7 +6,7 @@ modalmgr = hs.hotkey.modal.new(modalmgr_keys[1], modalmgr_keys[2], 'Toggle Modal
 -- end
 
 function modalmgr:exited()
-    modal_tray:hide()
+    if modal_tray then modal_tray:hide() end
     exit_others()
     if hotkeytext then
         hotkeytext:delete()


### PR DESCRIPTION
After I change the `modalmgr_keys` to other key map, every time I trigger the `modalmgr_keys`, the console shows an error: modal_tray is nill...