### PR TITLE
Changed the moveAndResize function to use frame

### DIFF
--- a/Spoons/WinWin.spoon/init.lua
+++ b/Spoons/WinWin.spoon/init.lua
@@ -132,7 +132,7 @@ function obj:moveAndResize(option)
     local cwin = hs.window.focusedWindow()
     if cwin then
         local cscreen = cwin:screen()
-        local cres = cscreen:fullFrame()
+        local cres = cscreen:frame()
         local stepw = cres.w/obj.gridparts
         local steph = cres.h/obj.gridparts
         local wf = cwin:frame()


### PR DESCRIPTION
I found that if I have the dock on the side resizing with
option-r+h/j/k/l would result in the window overlapping the dock.
Using frame instead of fullFrame in moveAndResize appears to correct this.